### PR TITLE
Add time display modes & ability to show only clock icon

### DIFF
--- a/common/src/main/java/com/mrmelon54/ClockHud/ClockHudRenderer.java
+++ b/common/src/main/java/com/mrmelon54/ClockHud/ClockHudRenderer.java
@@ -1,6 +1,7 @@
 package com.mrmelon54.ClockHud;
 
 import com.mrmelon54.ClockHud.enums.ClockPosition;
+import com.mrmelon54.ClockHud.enums.GameTimeDisplayMode;
 import dev.architectury.event.events.client.ClientGuiEvent;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
@@ -14,36 +15,50 @@ public class ClockHudRenderer implements ClientGuiEvent.RenderHud {
     public void renderHud(GuiGraphics graphics, float tickDelta) {
         ConfigStructure config = ClockHud.getConfig();
         Minecraft client = Minecraft.getInstance();
-        if (!config.clockEnabled || client.options.renderDebug) return;
+        if (client.options.renderDebug) return;
+        
+        long offsettedTimeInTicks = (client.level.dayTime() + 6000) % 24000;
+        String minutes = String.format("%02d", (int) ((double)(offsettedTimeInTicks/10 % 100)/100*60));
 
-        String clockText = client.level != null ? String.valueOf(client.level.dayTime() % 24000L) : "";
+        String clockText = client.level != null ? switch (config.timeDisplayMode) {
+            case TICKS -> String.valueOf(client.level.dayTime() % 24000);
+            case HRS24 -> String.valueOf(offsettedTimeInTicks/1000) + ":" + minutes;
+            case HRS12 -> String.valueOf(((offsettedTimeInTicks/1000) + 11) % 12 + 1) + ":" + minutes + ((offsettedTimeInTicks/1000 >= 12) ? " PM" : " AM");
+            default -> "";
+        } : "";
         int textLength = client.font.width(clockText);
         int textHeight = client.font.lineHeight;
 
-        int clockSize = config.iconEnabled ? 16 : 0;
-        int clockGap = config.iconEnabled ? 2 : 0;
+        int clockSize = config.clockIconEnabled ? 16 : 0;
+        int clockGap = config.clockIconEnabled ? 5 : 0;
         int offsetForIcon = clockSize + clockGap;
         int iconOffset = config.iconPosition == ClockPosition.RIGHT ? textLength + clockGap : 0;
         int clockY = switch (config.position.getVerticalPosition()) {
             case NEGATIVE -> 0;
             case NEUTRAL -> (textHeight - clockSize) / 2;
             case POSITIVE -> textHeight - clockSize;
+            default -> 0;
         };
 
         int myX = switch (config.position.getHorizontalPosition()) {
             case NEGATIVE -> config.xOffset;
             case NEUTRAL -> graphics.guiWidth() / 2 - (textLength + offsetForIcon) / 2 + config.xOffset;
             case POSITIVE -> graphics.guiWidth() - (textLength + offsetForIcon) + config.xOffset;
+            default -> config.xOffset;
         };
         int myY = switch (config.position.getVerticalPosition()) {
             case NEGATIVE -> config.yOffset;
             case NEUTRAL -> graphics.guiHeight() / 2 - textHeight / 2 + config.yOffset;
             case POSITIVE -> graphics.guiHeight() - textHeight + config.yOffset;
+            default -> config.yOffset;
         };
 
         if (clockItemStack == null) clockItemStack = new ItemStack(Items.CLOCK);
-        if (config.iconEnabled)
+        if (config.gameTimeDisplayEnabled) {
+            graphics.drawString(client.font, clockText, myX + (config.iconPosition == ClockPosition.LEFT ? offsetForIcon : 0), myY, config.color);
+        }
+        if (config.clockIconEnabled) {
             graphics.renderItem(clockItemStack, myX + iconOffset, myY + clockY, 0);
-        graphics.drawString(client.font, clockText, myX + (config.iconPosition == ClockPosition.LEFT ? offsetForIcon : 0), myY, config.colour);
+        }
     }
 }

--- a/common/src/main/java/com/mrmelon54/ClockHud/ConfigStructure.java
+++ b/common/src/main/java/com/mrmelon54/ClockHud/ConfigStructure.java
@@ -2,15 +2,21 @@ package com.mrmelon54.ClockHud;
 
 import com.mrmelon54.ClockHud.enums.ClockPosition;
 import com.mrmelon54.ClockHud.enums.DisplayPosition;
+import com.mrmelon54.ClockHud.enums.GameTimeDisplayMode;
+
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
 import me.shedaniel.autoconfig.annotation.ConfigEntry;
 
 @Config(name = "clock-hud")
-@Config.Gui.Background("minecraft:textures/block/cut_copper.png")
+@Config.Gui.Background("minecraft:textures/block/gold_block.png")
 public class ConfigStructure implements ConfigData {
-    public boolean clockEnabled = true;
-    public boolean iconEnabled = true;
+    public boolean gameTimeDisplayEnabled = true;
+
+    @ConfigEntry.Gui.EnumHandler(option = ConfigEntry.Gui.EnumHandler.EnumDisplayOption.BUTTON)
+    public GameTimeDisplayMode timeDisplayMode = GameTimeDisplayMode.HRS12;
+
+    public boolean clockIconEnabled = true;
 
     @ConfigEntry.Gui.EnumHandler(option = ConfigEntry.Gui.EnumHandler.EnumDisplayOption.BUTTON)
     public ClockPosition iconPosition = ClockPosition.RIGHT;
@@ -20,9 +26,9 @@ public class ConfigStructure implements ConfigData {
 
 
     @ConfigEntry.ColorPicker
-    public int colour = 0xffffff;
+    public int color = 0xffffff;
 
-    public int xOffset = -2;
+    public int xOffset = -5;
 
-    public int yOffset = -1;
+    public int yOffset = -5;
 }

--- a/common/src/main/java/com/mrmelon54/ClockHud/enums/GameTimeDisplayMode.java
+++ b/common/src/main/java/com/mrmelon54/ClockHud/enums/GameTimeDisplayMode.java
@@ -1,0 +1,17 @@
+package com.mrmelon54.ClockHud.enums;
+
+public enum GameTimeDisplayMode {
+    TICKS("Ticks"),
+    HRS24("24 Hour"),
+    HRS12("12 Hour");
+
+    private final String name;
+
+    GameTimeDisplayMode(String name) {
+        this.name = name;
+    }
+
+    public String toString() {
+        return name;
+    }
+}

--- a/common/src/main/resources/assets/clock_hud/lang/en_gb.json
+++ b/common/src/main/resources/assets/clock_hud/lang/en_gb.json
@@ -1,0 +1,11 @@
+{
+  "text.autoconfig.clock-hud.title": "Clock HUD",
+  "text.autoconfig.clock-hud.option.gameTimeDisplayEnabled": "Game Time Display Enabled?",
+  "text.autoconfig.clock-hud.option.timeDisplayMode": "Game Time Display Mode",
+  "text.autoconfig.clock-hud.option.clockIconEnabled": "Clock Icon Enabled?",
+  "text.autoconfig.clock-hud.option.iconPosition": "Relative Clock Icon Position",
+  "text.autoconfig.clock-hud.option.position": "Position",
+  "text.autoconfig.clock-hud.option.color": "Colour",
+  "text.autoconfig.clock-hud.option.xOffset": "X Offset",
+  "text.autoconfig.clock-hud.option.yOffset": "Y Offset"
+}

--- a/common/src/main/resources/assets/clock_hud/lang/en_us.json
+++ b/common/src/main/resources/assets/clock_hud/lang/en_us.json
@@ -1,10 +1,11 @@
 {
   "text.autoconfig.clock-hud.title": "Clock HUD",
-  "text.autoconfig.clock-hud.option.clockEnabled": "Clock Enabled?",
-  "text.autoconfig.clock-hud.option.iconEnabled": "Icon Enabled?",
-  "text.autoconfig.clock-hud.option.iconPosition": "Icon Position",
+  "text.autoconfig.clock-hud.option.gameTimeDisplayEnabled": "Game Time Display Enabled?",
+  "text.autoconfig.clock-hud.option.timeDisplayMode": "Game Time Display Mode",
+  "text.autoconfig.clock-hud.option.clockIconEnabled": "Clock Icon Enabled?",
+  "text.autoconfig.clock-hud.option.iconPosition": "Relative Clock Icon Position",
   "text.autoconfig.clock-hud.option.position": "Position",
-  "text.autoconfig.clock-hud.option.colour": "Colour",
+  "text.autoconfig.clock-hud.option.color": "Color",
   "text.autoconfig.clock-hud.option.xOffset": "X Offset",
   "text.autoconfig.clock-hud.option.yOffset": "Y Offset"
 }


### PR DESCRIPTION
## New features in this PR:
- Ticks (already existing), 24HR, 12HR modes for time display (tested and working correctly)
- Ability to show only clock icon when only icon is set to false
- Renamed some config descriptions to be clearer
## Screenshots
12 hr display in bottom right corner
![12 HR display](https://github.com/MrMelon54/clock_hud/assets/87292945/93287b58-32f4-4ac0-aa9a-e952a1ed0272)
Clearer config descriptions
![Improved config descriptions](https://github.com/MrMelon54/clock_hud/assets/87292945/8bd52f75-4cfa-4024-91e6-8bf7fcd1259f)
## Why?
I added these features for fun and for use on the current server I'm playing on. I feel they are additions that make ClockHUD easier to use and better in general, so I created this PR.